### PR TITLE
Fix validation error displaying.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -101,7 +101,7 @@ export const ColorInput = (props: ColorInputProps) => {
         onFocus={handleOpen}
         label={<FieldTitle label={label} source={source} resource={resource} isRequired={isRequired} />}
         error={!!(isTouched && error)}
-        helperText={helperText}
+        helperText={isTouched && error?.message ? error.message : helperText}
         className={className}
       />
       {show ? (


### PR DESCRIPTION
Validation errors are not displayed.  See example of `useInput()` usage:
https://marmelab.com/react-admin/Inputs.html#the-useinput-hook

So it is a fix for that, ex.:
![obraz](https://user-images.githubusercontent.com/1256986/229097655-528b0edc-6414-4a26-b065-c52e9bda304e.png)
